### PR TITLE
Checksum based on physical_record_count

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,6 @@ See [Caveats](#caveats) below. Optionally ignores the amounts in the account sum
 This value should be set only if you know that your bank uses this nonstandard calculation for
 account control values.
 
-* `options[:num_account_summary_continuation_records]` (Integer, Default: 0)
-The number of continuation records the account summary.
-
 * `options[:continuations_slash_delimit_end_of_line_only]` (Boolean, Default: False)
 This allows continuation records to begin with `88,\` and still have the text including the slash to be processed.
 
@@ -94,8 +91,7 @@ This allows continuation records to begin with `88,\` and still have the text in
 
 ```ruby
 Bai2::BaiFile.new(string_data,
-                  account_control_ignores_summary_amounts: true,
-                  num_account_summary_continuation_records: 3)
+                  account_control_ignores_summary_amounts: true)
 ```
 
 

--- a/lib/bai2.rb
+++ b/lib/bai2.rb
@@ -12,7 +12,6 @@ module Bai2
 
     DEFAULT_OPTIONS = {
       account_control_ignores_summary_amounts: false,
-      num_account_summary_continuation_records: 0,
       continuations_slash_delimit_end_of_line_only: false,
     }.freeze
 

--- a/lib/bai2/integrity.rb
+++ b/lib/bai2/integrity.rb
@@ -126,7 +126,7 @@ module Bai2
         # Account for the account header and the account trailer records
         # and any additional summary records (Some banks use continuation records
         # for account summaries, others put the summary data on the same row as the header)
-        additional_records = 2 + options[:num_account_summary_continuation_records]
+        additional_records = @header.physical_record_count + @trailer.physical_record_count
         actual_num_records = records + additional_records
 
         unless expectation[:records] == actual_num_records

--- a/test/tests/bai2.rb
+++ b/test/tests/bai2.rb
@@ -6,8 +6,7 @@ class Bai2Test < Minitest::Test
 
   def setup
     @daily = Bai2::BaiFile.parse(File.expand_path('../../data/daily.bai2', __FILE__))
-    @daily_with_summary = Bai2::BaiFile.parse(File.expand_path('../../data/daily_with_summary.bai2', __FILE__),
-                                              num_account_summary_continuation_records: 3)
+    @daily_with_summary = Bai2::BaiFile.parse(File.expand_path('../../data/daily_with_summary.bai2', __FILE__))
 
     @eod = Bai2::BaiFile.parse(File.expand_path('../../data/eod.bai2', __FILE__))
     @eod_no_as_of_time = Bai2::BaiFile.parse(File.expand_path('../../data/eod_without_as_of_time.bai2', __FILE__))
@@ -66,10 +65,6 @@ class Bai2Test < Minitest::Test
   end
 
   def test_integrity
-    assert_raises Bai2::BaiFile::IntegrityError do
-      # Calling without the options: num_account_summary_continuation_records => 3 should raise an error
-      Bai2::BaiFile.parse(File.expand_path('../../data/daily_with_summary.bai2', __FILE__))
-    end
     assert_raises Bai2::BaiFile::IntegrityError do
       # An invalid amount checksum should raise an error
       Bai2::BaiFile.parse(File.expand_path('../../data/invalid_checksum_eod.bai2', __FILE__))


### PR DESCRIPTION
Remove the `num_account_summary_continuation_records` field that is currently manually defined. 

This PR changes the checksum to validate based on the physical record count in each individual file, rather than placing a format expectation based on configuration. This should allow greater flexibility going forward.

Should resolve https://github.com/venturehacks/bai2/issues/10